### PR TITLE
Added BY 178 T tunable bulb.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This app allows you to connect your INNR Devices to Homey
 
 # Supported Devices
 
+* BY 178 T
 * RS 122 GU10 Spot For your recessed spotlights
 * RB 175 W Tunable White Bulb
 * RB 162
@@ -42,6 +43,6 @@ Any requests please post them in the https://forum.athom.com/discussion/3882/bet
 Please report issues at the [issues section on Github](https://github.com/kasteleman/com.innr/issues) otherwise in the above mentioned topic.     
 
 
-# Version 1.0.5
+# Version 1.0.6
 
-Fix for firmware issues of the dimmable puck, spot and ledstrips
+Added BY 178 T tunable bulb

--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
   "category": [
     "lights"
   ],
-  "version": "1.0.5",
+  "version": "1.0.6",
   "compatibility": ">=1.5.3",
   "sdk": 2,
   "author": {
@@ -325,7 +325,10 @@
       ],
       "zigbee": {
         "manufacturerName": "innr",
-        "productId": [ "RB 178 T" ],
+        "productId": [
+          "BY 178 T",
+          "RB 178 T"
+        ],
         "deviceId": 544,
         "profileId": 49246,
         "learnmode": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.innr",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "This app allows you to connect your INNR Devices to Homey",
   "main": "app.js",
   "dependencies": {


### PR DESCRIPTION
This is the bayonet (B22) version of the already supported RB 178 T, which is the edison screw (E27) version.

It is likely that there will be similar product IDs that need to be added for any other bayonet versions, but I do not have these to test so have not added them here.  If we can identify them, adding them should be a case of replicating what I've done here.  The deviceId and profileId stay the same but the productId changes.