### PR TITLE
Potential fix meter_power

### DIFF
--- a/drivers/smart_plug_sp120/device.js
+++ b/drivers/smart_plug_sp120/device.js
@@ -48,7 +48,7 @@ class SmartPlugSP120 extends ZigBeeDevice {
 				get: 'currentSummDelivered',
 				reportParser(value) {
 					this.log('value: ', value);
-					return Buffer.from(value).readUIntBE(0, 2) / 1000;
+					return value[1]/100;
 				},
 				report: 'currentSummDelivered',
 				getOpts: {
@@ -117,7 +117,7 @@ class SmartPlugSP120 extends ZigBeeDevice {
 				get: 'currentSummDelivered',
 				reportParser(value) {
 					this.log('value: ', value);
-					return Buffer.from(value).readUIntBE(0, 2) / 1000;
+					return value[1]/100;
 				},
 				report: 'currentSummDelivered',
 				getOpts: {


### PR DESCRIPTION
The meter_power always showed a to low number and resettet every ~0,25 kWh.
So I looked into it. 
currentSummDelivered is at start [0,0]
after 1,0 kWh it is [0,100]
and after about 3,5 kWh it is  [0,350]
So maybe It is just an array and the first zero isn't used. So "value[1]/100" gives me a right result.
But I will investigate further. Maybe there is somebody which has used much more kWh on that Plug. Sadly I can't find any documentation about the plug.