### PR TITLE
add FL 120 C to the RGBW strip

### DIFF
--- a/drivers/rgbw_strip/driver.compose.json
+++ b/drivers/rgbw_strip/driver.compose.json
@@ -28,7 +28,10 @@
   },
   "zigbee": {
     "manufacturerName": "innr",
-    "productId": "FL 130 C",
+    "productId": [
+      "FL 120 C",
+      "FL 130 C"
+    ],
     "deviceId": 528,
     "profileId": 49246,
     "learnmode": {


### PR DESCRIPTION
The FL 120 C is the 2m version of the FL 130 C. Just tested it and it works like a charm.